### PR TITLE
feat: add extern "C" guards and PlatformIO library.json

### DIFF
--- a/include/mazarbulib.h
+++ b/include/mazarbulib.h
@@ -15,6 +15,10 @@
 
 #include "mazarbulib_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -123,4 +127,8 @@ void mazarbulib_feed_char(mazarbulib_t *ctx, char c);
 // non-NULL) before rendering.
 void mazarbulib_tick(mazarbulib_t *ctx);
 
-#endif // MAZARBULIB_INCLUDE_MAZARBULIB_H_
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MAZARBULIB_INCLUDE_MAZARBULIB_H_

--- a/library.json
+++ b/library.json
@@ -1,0 +1,22 @@
+{
+  "name": "mazarbulib",
+  "version": "0.1.0",
+  "description": "UART tabular screen display library for embedded systems",
+  "license": "MIT",
+  "homepage": "https://github.com/reboot-required/MazarbuLib",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reboot-required/MazarbuLib"
+  },
+  "authors": [
+    {
+      "name": "Lukas Kraft",
+      "url": "https://github.com/reboot-required"
+    }
+  ],
+  "build": {
+    "srcDir": "src",
+    "includeDir": "include",
+    "flags": "-std=c99"
+  }
+}


### PR DESCRIPTION
- Wrap public API in extern "C" so mazarbulib.h can be included from Arduino/ESP-IDF C++ translation units without linker errors
- Add library.json PlatformIO manifest (src/include dirs, C99 flag)