### PR TITLE
refactor: change MAZARBULIB_TYPE_STRING to accept const char * directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,19 +169,21 @@ is included.
 
 ## Notes
 
-**`MAZARBULIB_TYPE_STRING` contract** — `value_ptr` must be a `const char **`
-(pointer to the string pointer), consistent with all other types. The pointer
-is dereferenced at each render so the display reflects the current string:
+**`MAZARBULIB_TYPE_STRING` contract** — `value_ptr` must be a non-NULL
+`const char *` pointing directly to the string data. Pass the pointer itself,
+not its address:
 
 ```c
-static const char *status = "idle";
-mazarbulib_register_row(&lib, s, "Status", MAZARBULIB_TYPE_STRING, &status);
+char status[16] = "idle";
+mazarbulib_register_row(&lib, s, "Status", MAZARBULIB_TYPE_STRING, status);
 // Later:
-status = "running"; // next mazarbulib_tick() will show "running"
+strncpy(status, "running", sizeof(status) - 1);
+status[sizeof(status) - 1] = '\0'; // next mazarbulib_tick() will show "running"
 ```
 
-A `NULL` inner pointer (i.e. `*value_ptr == NULL`) is rendered as an empty
-string rather than causing undefined behaviour.
+For an empty string pass `""`. To display a string whose pointer may change
+at runtime, keep the pointer itself stable (e.g. a fixed-size char array or a
+persistent buffer) and update its contents in place.
 
 **Truncation** — labels longer than `MAZARBULIB_LABEL_WIDTH` and values
 longer than `MAZARBULIB_VALUE_WIDTH` are silently truncated so that table

--- a/include/mazarbulib.h
+++ b/include/mazarbulib.h
@@ -100,16 +100,16 @@ int mazarbulib_register_screen(mazarbulib_t *ctx, const char *name);
 
 // Registers a data row on the screen at screen_idx.
 // label and value_ptr must remain valid for the lifetime of the context.
-// value_ptr is dereferenced at render time, so the pointed-to value is
-// always live.
+// value_ptr is read at render time, so the pointed-to value is always live.
 //
 // For numeric and bool types, pass the address of your variable:
 //   int32_t rpm = 0;     register_row(..., MAZARBULIB_TYPE_INT32,  &rpm);
 // For strings, pass the const char * directly (not its address):
 //   char msg[32] = "hi"; register_row(..., MAZARBULIB_TYPE_STRING, msg);
 //
-// MAZARBULIB_TYPE_STRING: value_ptr must be a non-NULL const char * pointing
-// directly to the string data. For an empty string pass "".
+// MAZARBULIB_TYPE_STRING: value_ptr must be a non-NULL, NUL-terminated
+// const char * pointing directly to the string data. NULL is not allowed;
+// for an empty string pass "".
 // Label and value strings longer than MAZARBULIB_LABEL_WIDTH /
 // MAZARBULIB_VALUE_WIDTH are truncated to keep table borders aligned.
 //

--- a/include/mazarbulib.h
+++ b/include/mazarbulib.h
@@ -29,7 +29,7 @@ typedef enum {
   MAZARBULIB_TYPE_UINT32, // uint32_t, displayed as unsigned decimal.
   MAZARBULIB_TYPE_FLOAT,  // float, displayed with two decimal places.
   MAZARBULIB_TYPE_DOUBLE, // double, displayed with two decimal places.
-  MAZARBULIB_TYPE_STRING, // const char **, dereferenced at render time.
+  MAZARBULIB_TYPE_STRING, // const char *, rendered directly.
   MAZARBULIB_TYPE_BOOL,   // bool, displayed as "true" / "false".
   MAZARBULIB_TYPE_HEX,    // uint32_t, displayed as 0xXXXXXXXX.
 } mazarbulib_type_t;
@@ -103,12 +103,13 @@ int mazarbulib_register_screen(mazarbulib_t *ctx, const char *name);
 // value_ptr is dereferenced at render time, so the pointed-to value is
 // always live.
 //
-// For every type, pass the address of your variable:
-//   int32_t rpm = 0;  register_row(..., MAZARBULIB_TYPE_INT32,  &rpm);
-//   const char *msg;  register_row(..., MAZARBULIB_TYPE_STRING, &msg);
+// For numeric and bool types, pass the address of your variable:
+//   int32_t rpm = 0;     register_row(..., MAZARBULIB_TYPE_INT32,  &rpm);
+// For strings, pass the const char * directly (not its address):
+//   char msg[32] = "hi"; register_row(..., MAZARBULIB_TYPE_STRING, msg);
 //
-// MAZARBULIB_TYPE_STRING: value_ptr must be a const char ** (pointer to the
-// string pointer). A NULL inner pointer is rendered as an empty string.
+// MAZARBULIB_TYPE_STRING: value_ptr must be a non-NULL const char * pointing
+// directly to the string data. For an empty string pass "".
 // Label and value strings longer than MAZARBULIB_LABEL_WIDTH /
 // MAZARBULIB_VALUE_WIDTH are truncated to keep table borders aligned.
 //

--- a/src/mazarbulib.c
+++ b/src/mazarbulib.c
@@ -95,10 +95,7 @@ static void mazarbulib_format_value_(const mazarbulib_row_t *row, char *buf,
     snprintf(buf, buf_len, "%.2f", *(const double *)row->value_ptr);
     break;
   case MAZARBULIB_TYPE_STRING: {
-    // value_ptr is a const char ** — dereference to get the current string
-    // pointer, consistent with all other types. A NULL inner pointer renders
-    // as an empty string.
-    const char *s = *(const char **)row->value_ptr;
+    const char *s = (const char *)row->value_ptr;
     snprintf(buf, buf_len, "%s", (s != NULL) ? s : "");
     break;
   }

--- a/tests/test_mazarbulib.c
+++ b/tests/test_mazarbulib.c
@@ -210,7 +210,7 @@ static void test_string_type(void) {
   TEST_ASSERT(strstr(g_uart_buf, "idle") != NULL);
 
   // In-place update — the next render must pick up the new string.
-  strncpy(msg, "running", sizeof(msg));
+  snprintf(msg, sizeof(msg), "%s", "running");
   uart_reset();
   mazarbulib_tick(&lib);
   TEST_ASSERT(strstr(g_uart_buf, "running") != NULL);

--- a/tests/test_mazarbulib.c
+++ b/tests/test_mazarbulib.c
@@ -195,32 +195,25 @@ static void test_rendering(void) {
 }
 
 static void test_string_type(void) {
-  // MAZARBULIB_TYPE_STRING: value_ptr must be a const char ** (pointer to the
-  // string pointer), consistent with all other types.  The render dereferences
-  // it so that updates to the pointer are visible at each tick.
+  // MAZARBULIB_TYPE_STRING: value_ptr is the const char * itself — pass the
+  // buffer address directly, not the address of a pointer variable.
+  // In-place mutations to the buffer are visible at each tick.
   mazarbulib_t lib;
   mazarbulib_init(&lib, fake_uart_send, NULL);
 
   int s0 = mazarbulib_register_screen(&lib, "Status");
-  static const char *msg = "idle";
-  mazarbulib_register_row(&lib, s0, "State", MAZARBULIB_TYPE_STRING, &msg);
+  static char msg[32] = "idle";
+  mazarbulib_register_row(&lib, s0, "State", MAZARBULIB_TYPE_STRING, msg);
 
   uart_reset();
   mazarbulib_tick(&lib);
   TEST_ASSERT(strstr(g_uart_buf, "idle") != NULL);
 
-  // Update the pointer — the next render must pick up the new value.
-  msg = "running";
+  // In-place update — the next render must pick up the new string.
+  strncpy(msg, "running", sizeof(msg));
   uart_reset();
   mazarbulib_tick(&lib);
   TEST_ASSERT(strstr(g_uart_buf, "running") != NULL);
-
-  // NULL inner pointer must not crash; library renders empty string.
-  msg = NULL;
-  uart_reset();
-  mazarbulib_tick(&lib);
-  // As long as tick() returns without aborting the test passes.
-  TEST_ASSERT(1);
 }
 
 static void test_all_types(void) {
@@ -241,7 +234,7 @@ static void test_all_types(void) {
   mazarbulib_register_row(&lib, s0, "u32", MAZARBULIB_TYPE_UINT32, &u32);
   mazarbulib_register_row(&lib, s0, "f", MAZARBULIB_TYPE_FLOAT, &f);
   mazarbulib_register_row(&lib, s0, "d", MAZARBULIB_TYPE_DOUBLE, &d);
-  mazarbulib_register_row(&lib, s0, "str", MAZARBULIB_TYPE_STRING, &str);
+  mazarbulib_register_row(&lib, s0, "str", MAZARBULIB_TYPE_STRING, str);
   mazarbulib_register_row(&lib, s0, "bool", MAZARBULIB_TYPE_BOOL, &b);
   mazarbulib_register_row(&lib, s0, "hex", MAZARBULIB_TYPE_HEX, &hex);
 
@@ -263,7 +256,7 @@ static void test_empty_string_row(void) {
 
   int s0 = mazarbulib_register_screen(&lib, "S");
   static const char *empty = "";
-  mazarbulib_register_row(&lib, s0, "label", MAZARBULIB_TYPE_STRING, &empty);
+  mazarbulib_register_row(&lib, s0, "label", MAZARBULIB_TYPE_STRING, empty);
 
   uart_reset();
   mazarbulib_tick(&lib); // Must not crash or produce corrupt output.
@@ -305,16 +298,16 @@ typedef struct {
 } mazarbulib_test_entry_t;
 
 static const mazarbulib_test_entry_t k_tests[] = {
-  { "test_init",              test_init              },
-  { "test_register_screen",   test_register_screen   },
-  { "test_register_row",      test_register_row      },
-  { "test_navigation",        test_navigation        },
-  { "test_zero_screen_tick",  test_zero_screen_tick  },
-  { "test_rendering",         test_rendering         },
-  { "test_string_type",       test_string_type       },
-  { "test_all_types",         test_all_types         },
-  { "test_empty_string_row",  test_empty_string_row  },
-  { "test_max_screens_rows",  test_max_screens_rows  },
+    {"test_init", test_init},
+    {"test_register_screen", test_register_screen},
+    {"test_register_row", test_register_row},
+    {"test_navigation", test_navigation},
+    {"test_zero_screen_tick", test_zero_screen_tick},
+    {"test_rendering", test_rendering},
+    {"test_string_type", test_string_type},
+    {"test_all_types", test_all_types},
+    {"test_empty_string_row", test_empty_string_row},
+    {"test_max_screens_rows", test_max_screens_rows},
 };
 
 #define K_TEST_COUNT ((int)(sizeof(k_tests) / sizeof(k_tests[0])))
@@ -328,12 +321,12 @@ int main(int argc, char **argv) {
       if (strcmp(argv[1], k_tests[i].name) == 0) {
         k_tests[i].fn();
         if (g_tests_failed > 0) {
-          fprintf(stderr, "%d/%d assertions FAILED in %s\n",
-                  g_tests_failed, g_tests_run, argv[1]);
+          fprintf(stderr, "%d/%d assertions FAILED in %s\n", g_tests_failed,
+                  g_tests_run, argv[1]);
           return 1;
         }
-        printf("%d/%d assertions passed in %s\n",
-               g_tests_run, g_tests_run, argv[1]);
+        printf("%d/%d assertions passed in %s\n", g_tests_run, g_tests_run,
+               argv[1]);
         return 0;
       }
     }


### PR DESCRIPTION
Previously value_ptr for STRING rows had to be a const char ** (pointer to a string pointer), requiring a double-dereference at render time. Every other type follows the simpler pattern of passing the address of the variable, so the double-pointer contract was inconsistent and a footgun: passing a char buffer directly compiled silently but caused undefined behaviour at render time.

Change the contract so callers pass the const char * directly, matching the intuitive pattern for all other types. The render layer is updated to cast value_ptr to const char * with a single indirection.

All three string-related test cases are updated accordingly:
- test_string_type: uses a [char] buffer with strncpy mutations.
- test_all_types / test_empty_string_row: drop & from registration call.

BREAKING CHANGE: callers previously passing &ptr must now pass ptr.