### PR TITLE
Bump version from 0.1.0 to 0.1.1

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "mazarbulib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "UART tabular screen display library for embedded systems",
   "license": "MIT",
   "homepage": "https://github.com/reboot-required/MazarbuLib",


### PR DESCRIPTION
This pull request updates the version number of the `mazarbulib` library from `0.1.0` to `0.1.1` in the `library.json` file. This is a minor version bump, typically indicating a small bug fix or minor improvement.